### PR TITLE
parse environ variables in .env_user 

### DIFF
--- a/scripts/scripts_executor.py
+++ b/scripts/scripts_executor.py
@@ -50,6 +50,8 @@ def load_secrets():
             if not line or line.startswith("#"):
                 continue
             if "=" in line:
+                if line.startswith("export "):
+                    line = line[len("export "):]
                 key, _, value = line.partition("=")
                 secrets[key.strip()] = value.strip()
     return secrets


### PR DESCRIPTION
parse environ variables in .env_user  with loadenv correctly even when statement export in front