### PR TITLE
add new keysight updated environment in the script that regenerates w…

### DIFF
--- a/workspace/setup_dev_env.sh
+++ b/workspace/setup_dev_env.sh
@@ -68,12 +68,12 @@ done
 [[ -n "$CONSTRAINTS_FILE" && -f "$CONSTRAINTS_FILE" ]] && rm "$CONSTRAINTS_FILE"
 # =============================================================================
 # SECTION 5 — HARDWARE FALLBACK
-# Adds the keysight-qcs-py312 site-packages as a fallback AFTER editable installs,
+# Adds the keysight-qcs-py312-274 site-packages as a fallback AFTER editable installs,
 # so dev_env packages always win. Named zzz_* to sort last.
-# (Needed for keysight and other hardware drivers only available in keysight-qcs-py312.)
+# (Needed for keysight and other hardware drivers only available in keysight-qcs-py312-274.)
 # =============================================================================
 VENV_SITE=$(python3 -c 'import site; print(site.getsitepackages()[0])')
-HARDWARE_SITE=~/envs/keysight-qcs-py312/lib/python3.12/site-packages
+HARDWARE_SITE=~/envs/keysight-qcs-py312-274/lib/python3.12/site-packages
 echo "$HARDWARE_SITE" > "$VENV_SITE/zzz_hardware_fallback.pth"
 echo "Created $VENV_SITE/zzz_hardware_fallback.pth -> $HARDWARE_SITE"
 # =============================================================================


### PR DESCRIPTION
The keysight-qcs-py312 environment was deprecated and substituted by keysight-qcs-py312-274
The file setup_dev_env.sh that helps re-create the workspace (ensuring all dependencies are resolved correctly) needed updating the naming in the paths in this section 
__
SECTION 5 — HARDWARE FALLBACK
 Adds the keysight-qcs-py312-274 site-packages as a fallback AFTER editable installs,
 so dev_env packages always win. Named zzz_* to sort last.
 (Needed for keysight and other hardware drivers only available in keysight-qcs-py312-274.)
__
VENV_SITE=$(python3 -c 'import site; print(site.getsitepackages()[0])')
HARDWARE_SITE=~/envs/keysight-qcs-py312-274/lib/python3.12/site-packages
echo "$HARDWARE_SITE" > "$VENV_SITE/zzz_hardware_fallback.pth"
echo "Created $VENV_SITE/zzz_hardware_fallback.pth -> $HARDWARE_SITE"
